### PR TITLE
Support expenses

### DIFF
--- a/internal/commands/immo/evaluate.go
+++ b/internal/commands/immo/evaluate.go
@@ -161,7 +161,7 @@ func evaluate(ctx EvaluationContext, good Good) EvaluationResult {
 			TotalPurchaseCost: math.Round(purchaseCost),
 			RemainingAssets:   math.Round(reminingAssets),
 		},
-		MaintenanceCost: MaintenanceCost{
+		OperationalCost: OperationalCost{
 			MonthlyMortgageCost:    math.Round(ctx.Mortgage.MonthlyCost + ctx.Mortgage.Insurance),
 			MonthlyHousingCharges:  math.Round(monthlyHousingCharges),
 			MonthlyExpenses:        math.Round(monthlyExpenses),

--- a/internal/commands/immo/types.go
+++ b/internal/commands/immo/types.go
@@ -50,7 +50,7 @@ type EvaluationContext struct {
 // EvaluationResult represents the result of an evaluation.
 type EvaluationResult struct {
 	PurchaseCost    PurchaseCost    `yaml:"purchase"`
-	MaintenanceCost MaintenanceCost `yaml:"maintenance"`
+	OperationalCost OperationalCost `yaml:"maintenance"`
 	Performance     GoodPerformance `yaml:"performance"`
 	Alerts          []string        `yaml:"alerts"`
 }
@@ -62,7 +62,7 @@ type PurchaseCost struct {
 	RemainingAssets   float64 `yaml:"remaining_assets"` // after initial contribution
 }
 
-type MaintenanceCost struct {
+type OperationalCost struct {
 	MonthlyMortgageCost    float64 `yaml:"monthly_mortgage_cost"`
 	MonthlyHousingCharges  float64 `yaml:"monthly_housing_charges"`
 	MonthlyExpenses        float64 `yaml:"monthly_expenses"`


### PR DESCRIPTION
When estimating the operational costs, we need to take into account the charges. Charges are proportional to the surface of the house. Bigger the house, higher the charges. It measures how the new project would impact our lifestyle.